### PR TITLE
Include version in jar name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     </dependencies>
 
     <build>
-        <finalName>AdvancedVanish</finalName>
+        <finalName>AdvancedVanish-${project.version}</finalName>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <resources>
             <resource>


### PR DESCRIPTION
Include plugin version in the final build.

The plugin also needs to have the build task ran as ACF has some broken changes on latest versions and the fix can only be applied when a new jar is built.